### PR TITLE
[WIP] Rep 19 create search result screen

### DIFF
--- a/cares-ui/package.json
+++ b/cares-ui/package.json
@@ -17,6 +17,7 @@
     "JsonBRE": "file:./engine",
     "axios": "^0.18.0",
     "immutable": "^4.0.0-rc.12",
+    "marked": "^0.6.0",
     "neutrino": "^8.3.0",
     "normalizr": "^3.3.0",
     "prop-types": "^15.6.2",

--- a/cares-ui/src/reporter/Search.jsx
+++ b/cares-ui/src/reporter/Search.jsx
@@ -1,88 +1,44 @@
 import { Component } from "react";
 import { Survey, Model, StylesManager } from "survey-react";
 // import * as Survey  from 'survey-react'
-import "survey-react/survey.css";
+import SearchJSON from "./jsonForms/search"
+import SearchResultsJSON from "./jsonForms/searchResults"
+import "survey-react/survey.css"
+import { setupModel } from './helpers/survey'
 
 export default class Search extends Component {
-  json = {
-    // checkErrorsMode: 'onComplete',
-    checkErrorsMode: "onValueChanged",
-    completeText: "Continue",
-    questionErrorLocation: "bottom",
-    elements: [
-      {
-        type: "text",
-        name: "first_name",
-        title: "First Name",
-        text: "Enter first name",
-        validators: [
-          {
-            type: 'expression',
-            expression: '{first_name} notempty or {last_name} notempty',
-            text: 'First Or Last Name is required'
-          }
-        ]
-      },
-      {
-        type: "text",
-        name: "last_name",
-        title: "Last Name",
-        startWithNewLine: false,
-        validators: [
-          {
-            type: 'expression',
-            expression: '{first_name} notempty or {last_name} notempty',
-            text: 'First Or Last Name is required'
-          }
-        ]
-      },
-
-      {
-        type: "text",
-        name: "number",
-        isRequired: true,
-        title: "Phone Number",
-        width: "30%"
-      },
-      {
-        type: "text",
-        name: "extension",
-        title: "Ext.",
-        width: "20%",
-        startWithNewLine: false
-      },
-      {
-        type: "dropdown",
-        name: "relationship",
-        title: "Relationship to Child",
-        optionsCaption: 'Reporter',
-        defaultValue: 'Reporter',
-        startWithNewLine: false
-      }
-    ],
-    completeSurveyText: "Save"
-  };
-
   constructor(props) {
-    super(props);
-
-    this.model = new Model(this.json);
-    this.model.onErrorCustomText.add((survey, options) => {
-      if (options.name === "required") {
-        options.text = "Required";
-      }
-    });
+    super(props)
+    this.search()
   }
 
-  onComplete(survey, options) {
-    // Write survey results into database
-    console.log("Survey results: " + JSON.stringify(survey.data));
+  search() {
+    this.model = setupModel(SearchJSON)
+    this.model.onComplete.add((result) => {
+      // this would be an action dispatch to update the store
+      // and re-render the component with updated search data
+      // it would also dynamically render the search results
+      this.setState({ results: this.model.data })
+      this.searchResults()
+    })
+  }
+
+  searchResults(setState = true) {
+    this.model = setupModel(SearchResultsJSON)
+    this.model.onComplete.add((result) => {
+      // this would be an action dispatch to create the reporter
+      // (maybe we need to use redux-saga)
+      // and re-render the component at the search screen
+      // it would also dynamically render a new survey
+      this.setState({ results: this.model.data })
+      this.search()
+    })
   }
 
   render() {
     // StylesManager.applyTheme('bootstrap')
     // Survey.cssType = 'bootstrap'
 
-    return <Survey model={this.model} onComplete={this.onComplete} />;
+    return <Survey model={this.model} />;
   }
 }

--- a/cares-ui/src/reporter/helpers/survey.js
+++ b/cares-ui/src/reporter/helpers/survey.js
@@ -1,0 +1,21 @@
+import marked from 'marked'
+import { Model } from "survey-react";
+
+export const setupModel = (json) => {
+  const model = new Model(json)
+  model.onErrorCustomText.add((survey, options) => {
+    if (options.name === "required") {
+      options.text = "Required"
+    }
+  })
+  model.onComplete.add((result) => {
+    console.log("Survey results: " + JSON.stringify(model.data))
+  })
+  model.onTextMarkdown.add((survey, options) => {
+    marked.setOptions({
+      breaks: true
+    })
+    options.html = marked(options.text)
+  })
+  return model
+}

--- a/cares-ui/src/reporter/jsonForms/search.json
+++ b/cares-ui/src/reporter/jsonForms/search.json
@@ -1,0 +1,58 @@
+{
+  "title": "New Incident Report",
+  "checkErrorsMode": "onValueChanged",
+  "completeText": "Continue",
+  "questionErrorLocation": "bottom",
+  "elements": [
+    {
+      "type": "text",
+      "name": "first_name",
+      "title": "First Name",
+      "text": "Enter first name",
+      "validators": [
+        {
+          "type": "expression",
+          "expression": "{first_name} notempty or {last_name} notempty",
+          "text": "First Or Last Name is required"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "name": "last_name",
+      "title": "Last Name",
+      "startWithNewLine": false,
+      "validators": [
+        {
+          "type": "expression",
+          "expression": "{first_name} notempty or {last_name} notempty",
+          "text": "First Or Last Name is required"
+        }
+      ]
+    },
+
+    {
+      "type": "text",
+      "name": "number",
+      "isRequired": true,
+      "title": "Call back phone number",
+      "width": "30%"
+    },
+    {
+      "type": "text",
+      "name": "extension",
+      "title": "Ext.",
+      "width": "20%",
+      "startWithNewLine": false
+    },
+    {
+      "type": "dropdown",
+      "name": "relationship",
+      "title": "Relationship to child",
+      "optionsCaption": "Reporter",
+      "defaultValue": "Reporter",
+      "startWithNewLine": false
+    }
+  ],
+  "completeSurveyText": "Save"
+}

--- a/cares-ui/src/reporter/jsonForms/searchResults.json
+++ b/cares-ui/src/reporter/jsonForms/searchResults.json
@@ -1,0 +1,32 @@
+{
+  "title": "New Incident Report",
+  "checkErrorsMode": "onValueChanged",
+  "completeText": "Continue",
+  "questionErrorLocation": "bottom",
+  "elements": [
+    {
+      "type": "panel",
+      "name": "existing reporter",
+      "elements": [
+        {
+          "type": "checkbox",
+          "choices": [
+            {
+              "value": "1",
+              "text": "Amit\n address\nphone number"
+            },
+            {
+              "value": "2",
+              "text": "Nesh\n address\nphone number"
+            },
+            {
+              "value": "3",
+              "text": "Tyler\n address\nphone number"
+            }
+          ],
+          "name": "Is there an existing match to reporter?"
+        }
+      ]
+    }
+  ]
+}

--- a/cares-ui/yarn.lock
+++ b/cares-ui/yarn.lock
@@ -6169,6 +6169,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+marked@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.6.0.tgz#a18d01cfdcf8d15c3c455b71c8329e5e0f01faa1"
+  integrity sha512-HduzIW2xApSXKXJSpCipSxKyvMbwRRa/TwMbepmlZziKdH8548WSoDP4SxzulEKjlo8BE39l+2fwJZuRKOln6g==
+
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"


### PR DESCRIPTION
Story: [REP-4](https://osi-cwds.atlassian.net/browse/REP-4)
Subtask: [REP-19](https://osi-cwds.atlassian.net/browse/REP-19)

Description: Create the screen that displays the search results with an option to continue.

Notes:
* right now, its just a mockup since its not connected to the API yet.
* search result text can be customized and built via markdown. There are other options we can explore, but lets just keep it simple now.
* connecting it to the API is simple: we just make Search a connected component, add the selectors to select search results (which means the search results will be passed through the props), and then use methods on the model to add options to the appropriate questions. Its not that hard!