### PR TITLE
REP 61: apply search json rules

### DIFF
--- a/cares-ui/engine/src/jsonBRE.js
+++ b/cares-ui/engine/src/jsonBRE.js
@@ -35,4 +35,8 @@ export default class JsonBRE {
     return Object.values(this.rules)
       .filter(predicate)
   }
+
+  empty () {
+    return Object.values(this.rules).length === 0
+  }
 }

--- a/cares-ui/engine/src/jsonSelector.js
+++ b/cares-ui/engine/src/jsonSelector.js
@@ -10,6 +10,6 @@ export default class JsonSelector {
   }
 
   applies (selector) {
-    return this.value === selector || tokenize(this.value).includes(selector)
+    return this.value === selector || tokenize(this.value).includes(selector) || this.directlyApplies(selector)
   }
 }

--- a/cares-ui/src/reporter/jsonForms/search.json
+++ b/cares-ui/src/reporter/jsonForms/search.json
@@ -4,56 +4,44 @@
   "checkErrorsMode": "onValueChanged",
   "completeText": "Continue",
   "questionErrorLocation": "bottom",
-  "elements": [
-    {
-      "type": "text",
-      "name": "first_name",
-      "title": "First Name",
-      "text": "Enter first name",
-      "validators": [
-        {
-          "type": "expression",
-          "expression": "{first_name} notempty or {last_name} notempty",
-          "text": "First Or Last Name is required"
-        }
-      ]
-    },
-    {
-      "type": "text",
-      "name": "last_name",
-      "title": "Last Name",
-      "startWithNewLine": false,
-      "validators": [
-        {
-          "type": "expression",
-          "expression": "{first_name} notempty or {last_name} notempty",
-          "text": "First Or Last Name is required"
-        }
-      ]
-    },
-
-    {
-      "type": "text",
-      "name": "number",
-      "isRequired": true,
-      "title": "Call back phone number",
-      "width": "30%"
-    },
-    {
-      "type": "text",
-      "name": "extension",
-      "title": "Ext.",
-      "width": "20%",
-      "startWithNewLine": false
-    },
-    {
-      "type": "dropdown",
-      "name": "relationship",
-      "title": "Relationship to child",
-      "optionsCaption": "Reporter",
-      "defaultValue": "Reporter",
-      "startWithNewLine": false
-    }
-  ],
+  "elements": [{
+    "type": "panel",
+    "name": "reporterName",
+    "elements": [
+      {
+        "type": "text",
+        "name": "first_name",
+        "title": "First Name",
+        "text": "Enter first name"
+      },
+      {
+        "type": "text",
+        "name": "last_name",
+        "title": "Last Name",
+        "startWithNewLine": false
+      }
+    ]},
+      {
+        "type": "text",
+        "name": "phone_number",
+        "title": "Call back phone number",
+        "width": "30%"
+      },
+      {
+        "type": "text",
+        "name": "extension",
+        "title": "Ext.",
+        "width": "20%",
+        "startWithNewLine": false
+      },
+      {
+        "type": "dropdown",
+        "name": "relationship",
+        "title": "Relationship to child",
+        "optionsCaption": "Reporter",
+        "defaultValue": "Reporter",
+        "startWithNewLine": false
+      }
+    ],
   "completeSurveyText": "Save"
 }

--- a/cares-ui/src/reporter/models/baseModel.js
+++ b/cares-ui/src/reporter/models/baseModel.js
@@ -1,9 +1,11 @@
 import { Model } from "survey-react";
+import JsonBRE from 'JsonBRE'
 import marked from 'marked'
 
 export default class BaseModel extends Model {
   constructor(json) {
     super(json)
+    this.engine = new JsonBRE()
 
     this.onErrorCustomText.add((survey, options) => {
       if (options.name === "required") {

--- a/cares-ui/src/reporter/models/searchModel.js
+++ b/cares-ui/src/reporter/models/searchModel.js
@@ -6,9 +6,13 @@ import marked from 'marked'
 import BaseModel from "./baseModel.js"
 
 export default class SearchModel extends BaseModel {
+
   constructor(props) {
     super(SearchJSON)
 
+    this.onAfterRenderSurvey.add(this.loadJsonRules.bind(this))
+    this.onValidatePanel.add(this.validateName.bind(this))
+    this.onValidateQuestion.add(this.validatePhoneNumber.bind(this))
     this.onCompleting.add((result, options) => {
       axios({
         url: searchRoute(),
@@ -18,6 +22,64 @@ export default class SearchModel extends BaseModel {
         props.setSearchResults && props.setSearchResults(result.data)
       })
     })
+  }
+
+  validationData() {
+    return {
+      search: {
+        reporter: {
+          ...this.data
+        }
+      }
+    }
+  }
+
+  validateName(sender, options) {
+    const firstNameRules = this.engine.find((rule) => rule.applies('search.reporter.first_name'))
+    const lastNameRules = this.engine.find((rule) => rule.applies('search.reporter.last_name'))
+    const rules = [...new Set([...firstNameRules, ...lastNameRules])]
+
+    const results = rules.map((rule) => this.engine.evaluate(rule, this.validationData()))
+    const errors = results.filter((result) => result !== true)
+    options.error = errors.join("\n") || undefined
+  }
+
+  validatePhoneNumber(sender, options) {
+    if(options.name === "phone_number") {
+      const rules = this.engine.find((rule) => rule.applies('search.reporter.phone_number'))
+      const results = rules.map((rule) => this.engine.evaluate(rule, this.validationData()))
+      const errors = results.filter((result) => result !== true)
+      options.error = errors.join("\n") || undefined
+    }
+  }
+
+  loadJsonRules() {
+    // temporary as these rules will be loaded from the api later
+    const nameRule = {
+      identifier: 'search-first-name-last-name-rule',
+      definition: {
+        "if": [
+          { "and":
+            [{ "missing": "search.reporter.first_name" },
+              { "missing": "search.reporter.last_name" }]
+          },
+          "Last name or first name is required to search for a reporter.",
+          true
+        ]
+      }
+    }
+    const phoneNumberRule = {
+      identifier: 'phone-number-rule',
+      definition: {
+        "if": [
+          { "missing": "search.reporter.phone_number" },
+          "A phone number is required to search for a reporter.",
+          true
+        ]
+      }
+    }
+    this.engine.define(nameRule)
+    this.engine.define(phoneNumberRule)
   }
 
   buildSearchQuery({first_name, last_name, number}) {

--- a/cares-ui/test/reporter/models/searchModel.test.js
+++ b/cares-ui/test/reporter/models/searchModel.test.js
@@ -1,5 +1,7 @@
 import SearchModel from '../../../src/reporter/models/searchModel'
 import { searchRoute } from '../../../src/routes'
+import { Survey } from "survey-react";
+import { mount } from 'enzyme'
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 
@@ -20,5 +22,40 @@ describe('SearchModel', () => {
 
     const model = new SearchModel(props)
     model.doComplete()
+  })
+
+  it('loads json rules for search after rendering', () => {
+    const model = new SearchModel()
+    const survey = mount(<Survey model={model}/>)
+    expect(model.engine.empty()).toEqual(false)
+  })
+
+  describe('validateName', () => {
+    it('validates that the first name and last name pass all business rules', () => {
+      const model = new SearchModel()
+      const options = {
+        name: 'first_name'
+      }
+      model.data = {
+        first_name: 'first',
+        last_name: 'last'
+      }
+      model.validateName({}, options)
+      expect(options.error).toEqual(undefined)
+    })
+  })
+
+  describe('validatePhoneNumber', () => {
+    it('validates that the phone number passes all business rules', () => {
+      const model = new SearchModel()
+      const options = {
+        name: 'phone_number'
+      }
+      model.data = {
+        phone_number: '1234567890'
+      }
+      model.validatePhoneNumber({}, options)
+      expect(options.error).toEqual(undefined)
+    })
   })
 })


### PR DESCRIPTION
## Description
This applies JSON rules for search on the front end: first name, last name, and phone number
## Jira Issue link
story: [REP-3](https://osi-cwds.atlassian.net/browse/REP-3)
task: [REP-61](https://osi-cwds.atlassian.net/browse/REP-61)

some notes:
* Added a method to the engine that checked if it has no rules
* fixed applies method -- if a selector applies then it also directly applies (applies is more loose)
* moved the elements in search model to a panel, so that the first name last name rule will be displayed above both elements. This means that all first name rules and last name rules will be displayed there as well.
* rules are hard coded until the api is ready