### PR TITLE
REP 88 refactor search results to its own component

### DIFF
--- a/cares-ui/src/index.jsx
+++ b/cares-ui/src/index.jsx
@@ -14,7 +14,13 @@ import ReporterMain from './reporter/ReporterMain';
 
 const store = createStore(rootReducer)
 
-const reporterStore = createStore(reporterReducer)
+const reporterStore = createStore(reporterReducer, {
+  models: {
+    search: {
+      active: true
+    }
+  }
+})
 
 const root = document.getElementById('root')
 const load = () => render((

--- a/cares-ui/src/reporter/ReportWizard.jsx
+++ b/cares-ui/src/reporter/ReportWizard.jsx
@@ -1,0 +1,14 @@
+import { Component } from "react";
+import Search from "./Search"
+import SearchResults from "./SearchResults"
+
+export class ReportWizard extends Component {
+  render () {
+    return (
+      <div>
+        <Search />
+        <SearchResults />
+      </div>
+    )
+  }
+}

--- a/cares-ui/src/reporter/ReporterMain.jsx
+++ b/cares-ui/src/reporter/ReporterMain.jsx
@@ -1,6 +1,6 @@
 import { Component } from  'react'
 import { Page } from '@cwds/components'
-import Search from './Search'
+import { ReportWizard } from './ReportWizard'
 
 export default class ReporterMain extends Component {
 
@@ -10,7 +10,7 @@ export default class ReporterMain extends Component {
         layout='jumpnav'
         title='Reporter Search'
         breadcrumb={<div>Reporter Search</div>}
-        main={Search}
+        main={ReportWizard}
       /> 
     ) 
   }

--- a/cares-ui/src/reporter/Search.jsx
+++ b/cares-ui/src/reporter/Search.jsx
@@ -4,47 +4,41 @@ import { Survey, StylesManager } from "survey-react";
 import "survey-react/survey.css"
 import { connect } from 'react-redux'
 import {
-  setSearchResults,
-  clearSearchResults
+  updateSearchModel,
+  updateSearchResultsModel
 } from './actions'
-import { selectReporterSearchResults } from './selectors'
 import SearchModel from './models/searchModel'
-import SearchResultsModel from './models/searchResultsModel'
+import {
+  selectSearchModelActive
+} from './selectors'
 
 export class Search extends Component {
   constructor(props) {
     super(props)
 
     const search = new SearchModel(this.props)
-    const results = new SearchResultsModel(this.props)
     search.onCompleting.add((result) => {
-      const data = this.model.data
-      this.model = results
-      // copy over the data so that we can create a reporter
-      this.model.data = data
+      updateSearchModel({
+        active: false,
+        data: this.model.data
+      })
+      updateSearchResultsModel({ active: true })
     })
-    results.onCompleting.add((result) => (this.model = search))
     this.model = search
-  }
-
-  componentDidUpdate() {
-    this.model.update(this.props)
   }
 
   render() {
     // StylesManager.applyTheme('bootstrap')
     // Survey.cssType = 'bootstrap'
 
-    return <Survey model={this.model} />;
+    if (this.props.active)
+      return <Survey model={this.model} />;
+    return null
   }
 }
 
 const mapStateToProps = (state, ownProps) => ({
-  searchResults: selectReporterSearchResults(state)
+  active: selectSearchModelActive(state)
 })
 
-const mapDispatchToProps = {
-  setSearchResults,
-  clearSearchResults
-}
-export default connect(mapStateToProps, mapDispatchToProps)(Search)
+export default connect(mapStateToProps)(Search)

--- a/cares-ui/src/reporter/Search.jsx
+++ b/cares-ui/src/reporter/Search.jsx
@@ -17,12 +17,13 @@ export class Search extends Component {
     super(props)
 
     const search = new SearchModel(this.props)
+    const { updateSearchModel, updateSearchResultsModel } = this.props
     search.onCompleting.add((result) => {
-      updateSearchModel({
+      updateSearchModel && updateSearchModel({
         active: false,
         data: this.model.data
       })
-      updateSearchResultsModel({ active: true })
+      updateSearchResultsModel && updateSearchResultsModel({ active: true })
     })
     this.model = search
   }
@@ -41,4 +42,9 @@ const mapStateToProps = (state, ownProps) => ({
   active: selectSearchModelActive(state)
 })
 
-export default connect(mapStateToProps)(Search)
+const mapDispatchToProps = ({
+  updateSearchModel,
+  updateSearchResultsModel
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(Search)

--- a/cares-ui/src/reporter/SearchResults.jsx
+++ b/cares-ui/src/reporter/SearchResults.jsx
@@ -16,15 +16,21 @@ import {
 export class SearchResults extends Component {
   constructor (props) {
     super(props)
-    const { data, onCompleting } = props
+    const {
+      data,
+      updateSearchResultsModel,
+      updateSearchModel,
+      clearSearchResults
+    } = props
 
     this.model = new SearchResultsModel(this.props)
     this.model.onCompleting.add((result) => {
-      updateSearchResultsModel({
+      updateSearchResultsModel && updateSearchResultsModel({
         active: false,
         data
       })
-      updateSearchModel({ active: true })
+      updateSearchModel && updateSearchModel({ active: true })
+      clearSearchResults && clearSearchResults()
     })
   }
 
@@ -47,7 +53,9 @@ const mapStateToProps = (state, ownProps) => ({
 
 const mapDispatchToProps = {
   setSearchResults,
-  clearSearchResults
+  clearSearchResults,
+  updateSearchModel,
+  updateSearchResultsModel
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(SearchResults)

--- a/cares-ui/src/reporter/SearchResults.jsx
+++ b/cares-ui/src/reporter/SearchResults.jsx
@@ -1,0 +1,53 @@
+import { Component } from "react";
+import { Survey } from "survey-react";
+import { connect } from 'react-redux'
+import {
+  setSearchResults,
+  clearSearchResults,
+  updateSearchModel,
+  updateSearchResultsModel
+} from './actions'
+import SearchResultsModel from './models/searchResultsModel'
+import {
+  selectReporterSearchResults,
+  selectSearchResultsModelActive
+} from './selectors'
+
+export class SearchResults extends Component {
+  constructor (props) {
+    super(props)
+    const { data, onCompleting } = props
+
+    this.model = new SearchResultsModel(this.props)
+    this.model.onCompleting.add((result) => {
+      updateSearchResultsModel({
+        active: false,
+        data
+      })
+      updateSearchModel({ active: true })
+    })
+  }
+
+  componentDidUpdate() {
+    const { data } = this.props
+    this.model.update(this.props, data)
+  }
+
+  render () {
+    if (this.props.active)
+      return <Survey model = {this.model} />
+    return null
+  }
+}
+
+const mapStateToProps = (state, ownProps) => ({
+  searchResults: selectReporterSearchResults(state),
+  active: selectSearchResultsModelActive(state)
+})
+
+const mapDispatchToProps = {
+  setSearchResults,
+  clearSearchResults
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(SearchResults)

--- a/cares-ui/src/reporter/SearchResults.jsx
+++ b/cares-ui/src/reporter/SearchResults.jsx
@@ -10,7 +10,8 @@ import {
 import SearchResultsModel from './models/searchResultsModel'
 import {
   selectReporterSearchResults,
-  selectSearchResultsModelActive
+  selectSearchResultsModelActive,
+  selectSearchModelData
 } from './selectors'
 
 export class SearchResults extends Component {
@@ -48,7 +49,8 @@ export class SearchResults extends Component {
 
 const mapStateToProps = (state, ownProps) => ({
   searchResults: selectReporterSearchResults(state),
-  active: selectSearchResultsModelActive(state)
+  active: selectSearchResultsModelActive(state),
+  data: selectSearchModelData(state)
 })
 
 const mapDispatchToProps = {

--- a/cares-ui/src/reporter/actions/index.js
+++ b/cares-ui/src/reporter/actions/index.js
@@ -1,5 +1,7 @@
 export const SET_SEARCH_RESULTS = 'SET_SEARCH_RESULTS'
 export const CLEAR_SEARCH_RESULTS = 'CLEAR_SEARCH_RESULTS'
+export const UPDATE_SEARCH_MODEL = 'UPDATE_SEARCH_MODEL'
+export const UPDATE_SEARCH_RESULTS_MODEL = 'UPDATE_SEARCH_RESULTS_MODEL'
 
 export const setSearchResults = payload => ({
   type: SET_SEARCH_RESULTS,
@@ -8,4 +10,16 @@ export const setSearchResults = payload => ({
 
 export const clearSearchResults = () => ({
   type: CLEAR_SEARCH_RESULTS
+})
+
+export const updateSearchModel = ({ active, data }) => ({
+  type: UPDATE_SEARCH_MODEL,
+  active,
+  data
+})
+
+export const updateSearchResultsModel = ({ active, data }) => ({
+  type: UPDATE_SEARCH_RESULTS_MODEL,
+  active,
+  data
 })

--- a/cares-ui/src/reporter/models/searchResultsModel.js
+++ b/cares-ui/src/reporter/models/searchResultsModel.js
@@ -8,11 +8,6 @@ export default class SearchResultsModel extends BaseModel {
 
 	this.loadJsonRules()
 	this.onValidateQuestion.add(this.validate.bind(this))
-    this.onCompleting.add((result, options) => {
-      options.allowComplete=false
-      props.clearSearchResults()
-      // in the future this will update the store
-    })
   }
 
   update (props, data) {

--- a/cares-ui/src/reporter/models/searchResultsModel.js
+++ b/cares-ui/src/reporter/models/searchResultsModel.js
@@ -15,7 +15,8 @@ export default class SearchResultsModel extends BaseModel {
     })
   }
 
-  update (props) {
+  update (props, data) {
+    this.data = data
     this.loadResults(props)
   }
 

--- a/cares-ui/src/reporter/reducers/index.js
+++ b/cares-ui/src/reporter/reducers/index.js
@@ -1,12 +1,15 @@
 import {
   SET_SEARCH_RESULTS,
-  CLEAR_SEARCH_RESULTS
+  CLEAR_SEARCH_RESULTS,
+  UPDATE_SEARCH_MODEL,
+  UPDATE_SEARCH_RESULTS_MODEL
 } from '../actions'
 import { searchResults } from '../schemas'
 import { normalize } from 'normalizr'
 
 export default (state = {}, action) => {
   console.log('reporter store state: ', state)
+  const { active, data } = action
   switch (action.type) {
     case SET_SEARCH_RESULTS:
       return {
@@ -22,6 +25,28 @@ export default (state = {}, action) => {
         ...state,
         entities: {
           ...rest
+        }
+      }
+    case UPDATE_SEARCH_MODEL:
+      return {
+        ...state,
+        models: {
+          ...state.models,
+          search: {
+            active,
+            data
+          }
+        }
+      }
+    case UPDATE_SEARCH_RESULTS_MODEL:
+      return {
+        ...state,
+        models: {
+          ...state.models,
+          search_results: {
+            active,
+            data
+          }
         }
       }
     default:

--- a/cares-ui/src/reporter/selectors/index.js
+++ b/cares-ui/src/reporter/selectors/index.js
@@ -18,3 +18,13 @@ export const selectReporterSearchResults = (rawState) => createSelector(
   (state) => state.getIn(['entities', 'person'], Map()).toList(),
   rawState
 )
+
+export const selectSearchResultsModelActive = (rawState) => createSelector(
+  (state) => state.getIn(['models', 'search_results', 'active']) || false,
+  rawState
+)
+
+export const selectSearchModelActive = (rawState) => createSelector(
+  (state) => state.getIn(['models', 'search', 'active']) || false,
+  rawState
+)

--- a/cares-ui/src/reporter/selectors/index.js
+++ b/cares-ui/src/reporter/selectors/index.js
@@ -28,3 +28,8 @@ export const selectSearchModelActive = (rawState) => createSelector(
   (state) => state.getIn(['models', 'search', 'active']) || false,
   rawState
 )
+
+export const selectSearchModelData = (rawState) => createSelector(
+  (state) => state.getIn(['models', 'search', 'data']) || {},
+  rawState
+)

--- a/cares-ui/test/reporter/models/searchResultsModel.test.js
+++ b/cares-ui/test/reporter/models/searchResultsModel.test.js
@@ -4,20 +4,6 @@ import { searchRoute } from '../../../src/routes'
 import { mount } from 'enzyme'
 
 describe('SearchResultsModel', () => {
-  it('clears the search results on continue', (done) => {
-    const props = {
-      clearSearchResults: (data) => true
-    }
-
-    spyOn(props, 'clearSearchResults').and.callFake((data) => {
-      expect(props.clearSearchResults).toHaveBeenCalled()
-      done()
-    })
-
-    const model = new SearchResultsModel(props)
-    model.doComplete()
-  })
-
   it('loads the search results from the props when there is an update', () => {
     const props = { }
     const model = new SearchResultsModel(props)

--- a/cares-ui/test/reporter/reportWizard.test.jsx
+++ b/cares-ui/test/reporter/reportWizard.test.jsx
@@ -1,0 +1,14 @@
+import { ReportWizard } from '../../src/reporter/ReportWizard'
+import { shallow } from 'enzyme'
+
+describe('ReportWizard', () => {
+  it('renders a search component', () => {
+    const reportWizard = shallow(<ReportWizard />)
+    expect(reportWizard.find('Connect(Search)').exists()).toBeTruthy()
+  })
+
+  it('renders a search results component', () => {
+    const reportWizard = shallow(<ReportWizard/>)
+    expect(reportWizard.find('Connect(SearchResults)').exists()).toBeTruthy()
+  })
+})

--- a/cares-ui/test/reporter/search.test.jsx
+++ b/cares-ui/test/reporter/search.test.jsx
@@ -4,7 +4,6 @@ import SearchJSON from "../../src/reporter/jsonForms/search"
 import SearchResultsJSON from "../../src/reporter/jsonForms/searchResults"
 
 import SearchModel from "../../src/reporter/models/searchModel"
-import SearchResultsModel from "../../src/reporter/models/searchResultsModel"
 
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
@@ -13,38 +12,46 @@ import { searchRoute } from '../../src/routes'
 export const mockAxios = new MockAdapter(axios)
 
 describe('Search', () => {
-  it('renders a search model', () => {
-    const search = shallow(<Search/>)
+  it('renders a search model when it is active', () => {
+    const search = shallow(<Search active={true} />)
     const survey = search.find('Survey')
     const searchModel = new SearchModel(search.props())
     expect(survey.props().model.toJSON()).toEqual(searchModel.toJSON())
   })
 
-  it('on completing the search it renders a search results model', () => {
-    const search = mount(<Search/>)
+  it('renders nothing when the search model is not active', () => {
+    const search = shallow(<Search active={false} />)
+    const survey = search.find('Survey')
+    expect(survey.exists()).toBeFalsy()
+  })
+
+  it('on completing the search it sets the search model as inactive with data', (done) => {
+    const updateSearchModel = jasmine.createSpy('updateSearchModel')
+    const search = mount(<Search active={true} updateSearchModel={updateSearchModel} />)
     const survey = search.find('Survey')
     mockAxios.onPost(searchRoute()).reply(200, {})
 
-    survey.props().model.onComplete.add((data) => {
-      const searchResultsModel = new SearchResultsModel(search.props())
-      expect(survey.props().model.toJSON()).toEqual(searchResultsModel.toJSON())
+    survey.props().model.onCompleting.add((data) => {
+      expect(updateSearchModel).toHaveBeenCalledWith({
+        active: false,
+        data: jasmine.anything()
+      })
       done()
     })
 
     survey.props().model.doComplete()
   })
 
-  it('on completing the search results it renders a search model', () => {
-    const search = mount(<Search/>)
+  it('on completing the search it sets the search results model as active', (done) => {
+    const updateSearchResultsModel = jasmine.createSpy('updateSearchModel')
+    const search = mount(<Search active={true} updateSearchResultsModel={updateSearchResultsModel} />)
     const survey = search.find('Survey')
     mockAxios.onPost(searchRoute()).reply(200, {})
 
-    survey.props().model.onComplete.add((data) => {
-      survey.props().model.onComplete.add((data) => {
-        const searchModel = new SearchModel(search.props())
-        expect(survey.props().model.toJSON()).toEqual(searchModel.toJSON())
+    survey.props().model.onCompleting.add((data) => {
+      expect(updateSearchResultsModel).toHaveBeenCalledWith({
+        active: true
       })
-      survey.props().model.doComplete()
       done()
     })
 

--- a/cares-ui/test/reporter/searchResults.test.jsx
+++ b/cares-ui/test/reporter/searchResults.test.jsx
@@ -1,0 +1,83 @@
+import { shallow, mount } from 'enzyme'
+import { SearchResults } from '../../src/reporter/SearchResults'
+import SearchResultsJSON from "../../src/reporter/jsonForms/searchResults"
+import SearchResultsModel from "../../src/reporter/models/searchResultsModel"
+
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { searchRoute } from '../../src/routes'
+
+export const mockAxios = new MockAdapter(axios)
+
+describe('SearchResults', () => {
+  it('renders a search results model when it is active', () => {
+    const search = shallow(<SearchResults active={true} />)
+    const survey = search.find('Survey')
+    const searchModel = new SearchResultsModel(search.props())
+    expect(survey.props().model.toJSON()).toEqual(searchModel.toJSON())
+  })
+
+  it('renders nothing when the search results amodel is not active', () => {
+    const search = shallow(<SearchResults active={false} />)
+    const survey = search.find('Survey')
+    expect(survey.exists()).toBeFalsy()
+  })
+
+  it('on completing the search results it sets the search model as active', (done) => {
+    const updateSearchModel = jasmine.createSpy('updateSearchModel')
+    const search = mount(<SearchResults
+      active={true}
+      updateSearchModel={updateSearchModel}
+    />)
+    const survey = search.find('Survey')
+    mockAxios.onPost(searchRoute()).reply(200, {})
+
+    survey.props().model.onCompleting.add((data) => {
+      expect(updateSearchModel).toHaveBeenCalledWith({
+        active: true,
+      })
+      done()
+    })
+
+    survey.props().model.doComplete()
+  })
+
+  it('on completing the search results it sets the search results model as inactive with data', (done) => {
+    const updateSearchResultsModel = jasmine.createSpy('updateSearchResultsModel')
+    const search = mount(<SearchResults
+      active={true}
+      data={{}}
+      updateSearchResultsModel={updateSearchResultsModel}
+    />)
+    const survey = search.find('Survey')
+    mockAxios.onPost(searchRoute()).reply(200, {})
+
+    survey.props().model.onCompleting.add((data) => {
+      expect(updateSearchResultsModel).toHaveBeenCalledWith({
+        active: false,
+        data: jasmine.anything()
+      })
+      done()
+    })
+
+    survey.props().model.doComplete()
+  })
+
+  it('on completing the search results it clears the search results', (done) => {
+    const clearSearchResults = jasmine.createSpy('clearSearchResults')
+    const search = mount(<SearchResults
+      active={true}
+      data={{}}
+      clearSearchResults={clearSearchResults}
+    />)
+    const survey = search.find('Survey')
+    mockAxios.onPost(searchRoute()).reply(200, {})
+
+    survey.props().model.onCompleting.add((data) => {
+      expect(clearSearchResults).toHaveBeenCalled()
+      done()
+    })
+
+    survey.props().model.doComplete()
+  })
+})


### PR DESCRIPTION
<!--- Dont forget the lable for PR -->

## Description
refactor the search results into their own component and connect it to the redux store

## Jira Issue link
story: [REP-3](https://osi-cwds.atlassian.net/browse/REP-3)
task: [REP-88](https://osi-cwds.atlassian.net/browse/REP-88)

Notes:
* we can refactor the selectors and reducer, so that we don't have to add code there every time we add a model. I will push that off if something higher priority comes up.
