### PR TITLE
REP 87 apply rules from BRE API

### DIFF
--- a/cares-ui/.neutrinorc.js
+++ b/cares-ui/.neutrinorc.js
@@ -13,7 +13,7 @@ module.exports = {
     [
       '@neutrinojs/dev-server', { disableHostCheck: true }
     ],
-    ['@neutrinojs/env', ['CARES_API_URL']],
+    ['@neutrinojs/env', ['CARES_API_URL', 'CARES_BRE_API_URL']],
     ['@neutrinojs/eslint', {
       eslint: {
         useEslintrc: true,

--- a/cares-ui/docker-compose-cares-ui.yml
+++ b/cares-ui/docker-compose-cares-ui.yml
@@ -7,3 +7,4 @@ services:
       - '3008:5000'
     environment:
       CARES_API_URL: http://api-a.sblegacy.cwds.io:3007
+      CARES_BRE_API_URL: http://api-a.sblegacy.cwds.io:3006

--- a/cares-ui/src/reporter/Search.jsx
+++ b/cares-ui/src/reporter/Search.jsx
@@ -40,6 +40,10 @@ export class Search extends Component {
     this.model = search
   }
 
+  componentDidMount() {
+    this.model.loadJsonRules()
+  }
+
   render() {
     if (this.props.active)
     {

--- a/cares-ui/src/reporter/SearchResults.jsx
+++ b/cares-ui/src/reporter/SearchResults.jsx
@@ -35,6 +35,10 @@ export class SearchResults extends Component {
     })
   }
 
+  componentDidMount() {
+    this.model.loadJsonRules()
+  }
+
   componentDidUpdate() {
     const { data } = this.props
     this.model.update(this.props, data)

--- a/cares-ui/src/reporter/models/searchModel.js
+++ b/cares-ui/src/reporter/models/searchModel.js
@@ -1,5 +1,10 @@
 import SearchJSON from "../jsonForms/search"
-import { searchRoute } from '../../routes'
+import {
+  searchRoute,
+  getBreRuleSetRoute
+} from '../../routes'
+
+import marked from 'marked'
 import BaseModel from "./baseModel.js"
 import axios from 'axios'
 
@@ -57,32 +62,17 @@ export default class SearchModel extends BaseModel {
   }
 
   loadJsonRules() {
-    // temporary as these rules will be loaded from the api later
-    const nameRule = {
-      identifier: 'search-first-name-last-name-rule',
-      definition: {
-        "if": [
-          { "and":
-            [{ "missing": "search.reporter.first_name" },
-              { "missing": "search.reporter.last_name" }]
-          },
-          "Last name or first name is required to search for a reporter.",
-          true
-        ]
-      }
-    }
-    const phoneNumberRule = {
-      identifier: 'phone-number-rule',
-      definition: {
-        "if": [
-          { "missing": "search.reporter.phone_number" },
-          "A phone number is required to search for a reporter.",
-          true
-        ]
-      }
-    }
-    this.engine.define(nameRule)
-    this.engine.define(phoneNumberRule)
+    axios({
+      url: getBreRuleSetRoute('ReporterSearchScreenBusinessRules'),
+      method: 'get',
+    }).then((result) => {
+      result.data.rules.map((rule) =>
+        this.engine.define({
+          identifier: rule.name,
+          definition: rule.logic
+        })
+      )
+    })
   }
 
   buildSearchQuery({first_name, last_name, number}) {

--- a/cares-ui/src/reporter/models/searchModel.js
+++ b/cares-ui/src/reporter/models/searchModel.js
@@ -61,7 +61,7 @@ export default class SearchModel extends BaseModel {
   }
 
   loadJsonRules() {
-    axios({
+    return axios({
       url: getBreRuleSetRoute('ReporterSearchScreenBusinessRules'),
       method: 'get',
     }).then((result) => {

--- a/cares-ui/src/reporter/models/searchModel.js
+++ b/cares-ui/src/reporter/models/searchModel.js
@@ -13,7 +13,6 @@ export default class SearchModel extends BaseModel {
   constructor(props) {
     super(SearchJSON)
 
-    this.onAfterRenderSurvey.add(this.loadJsonRules.bind(this))
     this.onValidatePanel.add(this.validateName.bind(this))
     this.onValidateQuestion.add(this.validatePhoneNumber.bind(this))
     this.onCompleting.add((result, options) => {

--- a/cares-ui/src/reporter/models/searchResultsModel.js
+++ b/cares-ui/src/reporter/models/searchResultsModel.js
@@ -3,7 +3,8 @@ import BaseModel from './baseModel'
 import { ItemValue, SurveyError } from "survey-react";
 import axios from 'axios'
 import {
-  createReporterRoute
+  createReporterRoute,
+  getBreRuleSetRoute
 } from '../../routes'
 
 export default class SearchResultsModel extends BaseModel {
@@ -98,40 +99,17 @@ export default class SearchResultsModel extends BaseModel {
 }
 
   loadJsonRules() {
-    // temporary as these rules will be loaded from the api later
-    const firstNameRule = {
-      identifier: 'create-reporter-first-name-rule',
-	  definition: {
-		"if": [
-		  { "missing": "create.reporter.first_name" },
-		  "A first name is required to create a reporter.",
-		  true
-		]
-	  }
-	}
-    const lastNameRule = {
-      identifier: 'create-reporter-last-name-rule',
-	  definition: {
-		"if": [
-		  { "missing": "create.reporter.last_name" },
-		  "A last name is required to create a reporter.",
-		  true
-		]
-	  }
-	}
-    const phoneNumberRule = {
-      identifier: 'create-reporter-phone-number-rule',
-	  definition: {
-		"if": [
-		  { "missing": "create.reporter.phone_number" },
-		  "A phone number is required to create a reporter.",
-		  true
-		]
-	  }
-    }
-    this.engine.define(firstNameRule)
-    this.engine.define(lastNameRule)
-    this.engine.define(phoneNumberRule)
+    axios({
+      url: getBreRuleSetRoute('ReporterCreateScreenBusinessRules'),
+      method: 'get',
+    }).then((result) => {
+      result.data.rules.map((rule) =>
+        this.engine.define({
+          identifier: rule.name,
+          definition: rule.logic
+        })
+      )
+    })
   }
 }
 

--- a/cares-ui/src/reporter/models/searchResultsModel.js
+++ b/cares-ui/src/reporter/models/searchResultsModel.js
@@ -12,7 +12,6 @@ export default class SearchResultsModel extends BaseModel {
     super(SearchResultsJSON)
 
     this.completeText = "Create Reporter"
-    this.loadJsonRules()
     this.onValidatePanel.add(this.validate.bind(this))
     this.onValidateQuestion.add(this.setContinueText.bind(this))
     this.onCompleting.add(this.createReporter.bind(this))

--- a/cares-ui/src/reporter/models/searchResultsModel.js
+++ b/cares-ui/src/reporter/models/searchResultsModel.js
@@ -99,7 +99,7 @@ export default class SearchResultsModel extends BaseModel {
 }
 
   loadJsonRules() {
-    axios({
+    return axios({
       url: getBreRuleSetRoute('ReporterCreateScreenBusinessRules'),
       method: 'get',
     }).then((result) => {

--- a/cares-ui/src/routes.js
+++ b/cares-ui/src/routes.js
@@ -1,5 +1,7 @@
 const caresApiRoute = (extension) => process.env.CARES_API_URL + extension
 
+const caresBreApiRoute = (extension) => process.env.CARES_BRE_API_URL + extension
+
 export const getAllReferralsRoute = () => caresApiRoute('/referrals')
 
 export const getReferralByIdRoute = (id) => caresApiRoute(`/referrals/${id}`)
@@ -21,3 +23,7 @@ export const searchRoute = () => caresApiRoute('/searches')
 // reporter routes
 
 export const createReporterRoute = () => caresApiRoute('/reporters')
+
+// business rules routes
+
+export const getBreRuleSetRoute = (ruleSet) => caresBreApiRoute(`/bre/defs/${ruleSet}`)

--- a/cares-ui/test-setup.js
+++ b/cares-ui/test-setup.js
@@ -1,4 +1,5 @@
 import { configure } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 
+global.XMLHttpRequest = undefined
 configure({ adapter: new Adapter() })

--- a/cares-ui/test/reporter/models/searchModel.test.js
+++ b/cares-ui/test/reporter/models/searchModel.test.js
@@ -74,8 +74,8 @@ describe('SearchModel', () => {
       })
       const model = new SearchModel()
       model.loadJsonRules().then(() => {
-        const rule = model.engine.find((rule) => rule.identifier === 'rule')
-        expect(rule).toEqual(rule)
+        const foundRule = model.engine.find((rule) => rule.identifier === 'rule')
+        expect(foundRule[0].definition).toEqual(rule)
         done()
       })
     })

--- a/cares-ui/test/reporter/models/searchModel.test.js
+++ b/cares-ui/test/reporter/models/searchModel.test.js
@@ -1,18 +1,27 @@
 import SearchModel from '../../../src/reporter/models/searchModel'
-import { searchRoute } from '../../../src/routes'
+import {
+  searchRoute,
+  getBreRuleSetRoute
+} from '../../../src/routes'
 import { Survey } from "survey-react";
 import { mount } from 'enzyme'
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 
+const mockAxios = new MockAdapter(axios)
+
 describe('SearchModel', () => {
+  afterEach(() => {
+    mockAxios.reset()
+  })
+
   it('makes an api call to search on complete and sets search results', (done) => {
     const props = {
       setSearchResults: (data) => true
     }
-    const mockAxios = new MockAdapter(axios)
 
     mockAxios.onPost(searchRoute()).reply(200, {})
+    mockAxios.onGet(getBreRuleSetRoute('ReporterSearchScreenBusinessRules')).reply(200, { rules: [] })
     spyOn(props, 'setSearchResults').and.callFake((data) => {
       expect(mockAxios.history.post.length).toEqual(1)
       expect(props.setSearchResults).toHaveBeenCalledWith({})
@@ -21,12 +30,6 @@ describe('SearchModel', () => {
 
     const model = new SearchModel(props)
     model.doComplete()
-  })
-
-  it('loads json rules for search after rendering', () => {
-    const model = new SearchModel()
-    const survey = mount(<Survey model={model}/>)
-    expect(model.engine.empty()).toEqual(false)
   })
 
   describe('validateName', () => {
@@ -55,6 +58,26 @@ describe('SearchModel', () => {
       }
       model.validatePhoneNumber({}, options)
       expect(options.error).toEqual(undefined)
+    })
+  })
+
+  describe('loadJsonRules', () => {
+    it('loads the json rules from an api', (done) => {
+      const rule = {
+        "and": [1,2]
+      }
+      mockAxios.onGet(getBreRuleSetRoute('ReporterSearchScreenBusinessRules')).reply(200, {
+        rules: [{
+          name: 'rule',
+          logic: rule
+        }]
+      })
+      const model = new SearchModel()
+      model.loadJsonRules().then(() => {
+        const rule = model.engine.find((rule) => rule.identifier === 'rule')
+        expect(rule).toEqual(rule)
+        done()
+      })
     })
   })
 })

--- a/cares-ui/test/reporter/models/searchResultsModel.test.js
+++ b/cares-ui/test/reporter/models/searchResultsModel.test.js
@@ -21,12 +21,6 @@ describe('SearchResultsModel', () => {
     expect(model.loadResults).toHaveBeenCalledWith(props)
   })
 
-  xit('loads json rules for search after rendering', () => {
-    const model = new SearchResultsModel()
-    const survey = mount(<Survey model={model}/>)
-    expect(model.engine.empty()).toEqual(false)
-  })
-
   describe('createReporter', () => {
     it('creates a reporter', () => {
       mockAxios.onPost(createReporterRoute()).reply(200)

--- a/cares-ui/test/reporter/models/searchResultsModel.test.js
+++ b/cares-ui/test/reporter/models/searchResultsModel.test.js
@@ -4,9 +4,12 @@ import { searchRoute } from '../../../src/routes'
 import { mount } from 'enzyme'
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
-import { createReporterRoute } from '../../../src/routes'
+import {
+  createReporterRoute,
+  getBreRuleSetRoute
+} from '../../../src/routes'
 
-export const mockAxios = new MockAdapter(axios)
+const mockAxios = new MockAdapter(axios)
 
 describe('SearchResultsModel', () => {
   it('loads the search results from the props when there is an update', () => {
@@ -18,7 +21,7 @@ describe('SearchResultsModel', () => {
     expect(model.loadResults).toHaveBeenCalledWith(props)
   })
 
-  it('loads json rules for search after rendering', () => {
+  xit('loads json rules for search after rendering', () => {
     const model = new SearchResultsModel()
     const survey = mount(<Survey model={model}/>)
     expect(model.engine.empty()).toEqual(false)
@@ -56,6 +59,26 @@ describe('SearchResultsModel', () => {
       }
       model.validate({}, options)
       expect(options.error).toEqual(undefined)
+    })
+  })
+
+  describe('loadJsonRules', () => {
+    it('loads the json rules from an api', (done) => {
+      const rule = {
+        "and": [1,2]
+      }
+      mockAxios.onGet(getBreRuleSetRoute('ReporterCreateScreenBusinessRules')).reply(200, {
+        rules: [{
+          name: 'rule',
+          logic: rule
+        }]
+      })
+      const model = new SearchResultsModel()
+      model.loadJsonRules().then(() => {
+        const rule = model.engine.find((rule) => rule.identifier === 'rule')
+        expect(rule).toEqual(rule)
+        done()
+      })
     })
   })
 })

--- a/cares-ui/test/reporter/search.test.jsx
+++ b/cares-ui/test/reporter/search.test.jsx
@@ -2,18 +2,22 @@ import { shallow, mount } from 'enzyme'
 import { Search } from '../../src/reporter/Search'
 import SearchJSON from "../../src/reporter/jsonForms/search"
 import SearchResultsJSON from "../../src/reporter/jsonForms/searchResults"
-
-import SearchModel from "../../src/reporter/models/searchModel"
-
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
-import { searchRoute } from '../../src/routes'
 
 export const mockAxios = new MockAdapter(axios)
 
+import SearchModel from "../../src/reporter/models/searchModel"
+
+import {
+  searchRoute,
+  getBreRuleSetRoute
+} from '../../src/routes'
+
+
 describe('Search', () => {
   it('renders a search model when it is active', () => {
-    const search = shallow(<Search active={true} />)
+    const search = shallow(<Search active={true} />, { disableLifecycleMethods: true })
     const survey = search.find('Survey')
     expect(survey.length).toEqual(1)
     const searchModel = new SearchModel(search.props())
@@ -26,16 +30,26 @@ describe('Search', () => {
   })
 
   it('renders nothing when the search model is not active', () => {
-    const search = shallow(<Search active={false} />)
+    const search = shallow(<Search active={false} />, { disableLifecycleMethods: true })
     const survey = search.find('Survey')
     expect(survey.exists()).toBeFalsy()
   })
 
+  it('loads business rules before the component renders', () => {
+    mockAxios.onGet(getBreRuleSetRoute('ReporterSearchScreenBusinessRules')).reply(200, { rules: [] })
+    const search = shallow(<Search active={true}/>)
+    const model = search.instance().model
+    const spy = jest.spyOn(model, 'loadJsonRules')
+    search.instance().componentDidMount()
+    expect(spy).toHaveBeenCalled()
+  })
+
   it('on completing the search it sets the search model as inactive with data', (done) => {
     const updateSearchModel = jasmine.createSpy('updateSearchModel')
-    const search = mount(<Search active={true} updateSearchModel={updateSearchModel} />)
+    const search = mount(
+      <Search active={true} updateSearchModel={updateSearchModel} />,
+      { disableLifecycleMethods: true })
     const survey = search.find('Survey')
-    mockAxios.onPost(searchRoute()).reply(200, {})
 
     survey.props().model.onCompleting.add((data) => {
       expect(updateSearchModel).toHaveBeenCalledWith({
@@ -50,9 +64,11 @@ describe('Search', () => {
 
   it('on completing the search it sets the search results model as active', (done) => {
     const updateSearchResultsModel = jasmine.createSpy('updateSearchModel')
-    const search = mount(<Search active={true} updateSearchResultsModel={updateSearchResultsModel} />)
+    const search = mount(
+      <Search active={true} updateSearchResultsModel={updateSearchResultsModel} />,
+      { disableLifecycleMethods: true }
+    )
     const survey = search.find('Survey')
-    mockAxios.onPost(searchRoute()).reply(200, {})
 
     survey.props().model.onCompleting.add((data) => {
       expect(updateSearchResultsModel).toHaveBeenCalledWith({

--- a/cares-ui/test/reporter/searchResults.test.jsx
+++ b/cares-ui/test/reporter/searchResults.test.jsx
@@ -5,20 +5,23 @@ import SearchResultsModel from "../../src/reporter/models/searchResultsModel"
 
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
-import { searchRoute } from '../../src/routes'
+import {
+  searchRoute,
+  getBreRuleSetRoute
+} from '../../src/routes'
 
 export const mockAxios = new MockAdapter(axios)
 
 describe('SearchResults', () => {
   it('renders a search results model when it is active', () => {
-    const search = shallow(<SearchResults active={true} />)
+    const search = shallow(<SearchResults active={true}/>, { disableLifecycleMethods: true })
     const survey = search.find('Survey')
     const searchModel = new SearchResultsModel(search.props())
     expect(survey.props().model.toJSON()).toEqual(searchModel.toJSON())
   })
 
   it('renders nothing when the search results amodel is not active', () => {
-    const search = shallow(<SearchResults active={false} />)
+    const search = shallow(<SearchResults active={false} />, { disableLifecycleMethods: true })
     const survey = search.find('Survey')
     expect(survey.exists()).toBeFalsy()
   })
@@ -28,7 +31,9 @@ describe('SearchResults', () => {
     const search = mount(<SearchResults
       active={true}
       updateSearchModel={updateSearchModel}
-    />)
+    />,
+    { disableLifecycleMethods: true }
+    )
     const survey = search.find('Survey')
     mockAxios.onPost(searchRoute()).reply(200, {})
 
@@ -48,7 +53,7 @@ describe('SearchResults', () => {
       active={true}
       data={{}}
       updateSearchResultsModel={updateSearchResultsModel}
-    />)
+    />, { disableLifecycleMethods: true })
     const survey = search.find('Survey')
     mockAxios.onPost(searchRoute()).reply(200, {})
 
@@ -69,7 +74,7 @@ describe('SearchResults', () => {
       active={true}
       data={{}}
       clearSearchResults={clearSearchResults}
-    />)
+    />, { disableLifecycleMethods: true })
     const survey = search.find('Survey')
     mockAxios.onPost(searchRoute()).reply(200, {})
 

--- a/cares-ui/test/reporter/searchResults.test.jsx
+++ b/cares-ui/test/reporter/searchResults.test.jsx
@@ -7,7 +7,8 @@ import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import {
   searchRoute,
-  getBreRuleSetRoute
+  getBreRuleSetRoute,
+  createReporterRoute
 } from '../../src/routes'
 
 export const mockAxios = new MockAdapter(axios)
@@ -27,6 +28,7 @@ describe('SearchResults', () => {
   })
 
   it('on completing the search results it sets the search model as active', (done) => {
+    mockAxios.onPost(createReporterRoute()).reply(200)
     const updateSearchModel = jasmine.createSpy('updateSearchModel')
     const search = mount(<SearchResults
       active={true}
@@ -48,6 +50,7 @@ describe('SearchResults', () => {
   })
 
   it('on completing the search results it sets the search results model as inactive with data', (done) => {
+    mockAxios.onPost(createReporterRoute()).reply(200)
     const updateSearchResultsModel = jasmine.createSpy('updateSearchResultsModel')
     const search = mount(<SearchResults
       active={true}
@@ -69,6 +72,7 @@ describe('SearchResults', () => {
   })
 
   it('on completing the search results it clears the search results', (done) => {
+    mockAxios.onPost(createReporterRoute()).reply(200)
     const clearSearchResults = jasmine.createSpy('clearSearchResults')
     const search = mount(<SearchResults
       active={true}


### PR DESCRIPTION
<!--- Dont forget the lable for PR -->

## Description
Apply the rules from JSON BRE instead of hard coding them.

## Jira Issue link
story: [REP-3](https://osi-cwds.atlassian.net/browse/REP-3)
task: [REP-87](https://osi-cwds.atlassian.net/browse/REP-87)

Notes:
* The rules are loaded straight into the engine. We could load them into the store and then *somehow* connect the engine to the store so that it uses the rules from the store. That seems like a large effort, and I would prefer to explore that later if we need to. Since the rules are only needed in the engine, its fine to load them directly.
* I should probably make the engine to be a normal instance and not a singleton. I will think about that as part of a refactoring effort. Since the engine is a singleton, it is shared across models and has all the rules ... and that may not be necessary.
* error handling will need to be addressed (preferably in a separate task)