### PR TITLE
REP 58 create reporter with mock api

### DIFF
--- a/cares-ui/src/reporter/jsonForms/searchResults.json
+++ b/cares-ui/src/reporter/jsonForms/searchResults.json
@@ -1,7 +1,6 @@
 {
   "title": "New Incident Report",
   "checkErrorsMode": "onValueChanged",
-  "completeText": "Continue",
   "questionErrorLocation": "bottom",
   "elements": [
     {
@@ -12,7 +11,7 @@
           "type": "checkbox",
           "name": "reporter",
           "choices": [],
-          "name": "Is there an existing match to reporter?"
+          "title": "Is there an existing match to reporter?"
         }
       ]
     }

--- a/cares-ui/src/reporter/models/searchResultsModel.js
+++ b/cares-ui/src/reporter/models/searchResultsModel.js
@@ -1,6 +1,10 @@
 import SearchResultsJSON from "../jsonForms/searchResults"
 import BaseModel from './baseModel'
 import { ItemValue, SurveyError } from "survey-react";
+import axios from 'axios'
+import {
+  createReporterRoute
+} from '../../routes'
 
 export default class SearchResultsModel extends BaseModel {
   constructor (props) {
@@ -10,6 +14,34 @@ export default class SearchResultsModel extends BaseModel {
     this.loadJsonRules()
     this.onValidatePanel.add(this.validate.bind(this))
     this.onValidateQuestion.add(this.setContinueText.bind(this))
+    this.onCompleting.add(this.createReporter.bind(this))
+  }
+
+  createReporter (result, options) {
+    return axios({
+      url: createReporterRoute(),
+      method: 'post',
+      data: this.buildReporter(result.data)})
+    .then((result) => {
+      this.onCompleting.error = false
+    })
+    .catch((error) => {
+      this.onCompleting.error = true
+    })
+  }
+
+  buildReporter ({
+    first_name,
+    last_name,
+    phone_number,
+    relationship
+  }) {
+    return {
+      first_name,
+      last_name,
+      phone_number: parseInt(phone_number),
+      relation_to_child: relationship
+    }
   }
 
   update (props, data) {

--- a/cares-ui/src/reporter/models/searchResultsModel.js
+++ b/cares-ui/src/reporter/models/searchResultsModel.js
@@ -6,8 +6,10 @@ export default class SearchResultsModel extends BaseModel {
   constructor (props) {
     super(SearchResultsJSON)
 
-	this.loadJsonRules()
-	this.onValidateQuestion.add(this.validate.bind(this))
+    this.completeText = "Create Reporter"
+    this.loadJsonRules()
+    this.onValidatePanel.add(this.validate.bind(this))
+    this.onValidateQuestion.add(this.setContinueText.bind(this))
   }
 
   update (props, data) {
@@ -34,6 +36,16 @@ export default class SearchResultsModel extends BaseModel {
         element.addError(new SurveyError("There are no matching existing reporters"))
       }
     }
+  }
+
+  setContinueText(sender, options) {
+    if(options.name === "reporter") {
+      if (options.question.isEmpty())
+        this.completeText = "Create Reporter"
+      else
+        this.completeText = "Continue"
+    }
+    this.render()
   }
 
   validationData() {

--- a/cares-ui/src/routes.js
+++ b/cares-ui/src/routes.js
@@ -17,3 +17,7 @@ export const putAddressRoute = (address_id) => caresApiRoute(`/addresses/${addre
 // search routes
 
 export const searchRoute = () => caresApiRoute('/searches')
+
+// reporter routes
+
+export const createReporterRoute = () => caresApiRoute('/reporters')

--- a/cares-ui/test/reporter/models/searchResultsModel.test.js
+++ b/cares-ui/test/reporter/models/searchResultsModel.test.js
@@ -2,6 +2,11 @@ import SearchResultsModel from '../../../src/reporter/models/searchResultsModel'
 import { Survey } from "survey-react";
 import { searchRoute } from '../../../src/routes'
 import { mount } from 'enzyme'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { createReporterRoute } from '../../../src/routes'
+
+export const mockAxios = new MockAdapter(axios)
 
 describe('SearchResultsModel', () => {
   it('loads the search results from the props when there is an update', () => {
@@ -17,6 +22,27 @@ describe('SearchResultsModel', () => {
     const model = new SearchResultsModel()
     const survey = mount(<Survey model={model}/>)
     expect(model.engine.empty()).toEqual(false)
+  })
+
+  describe('createReporter', () => {
+    it('creates a reporter', () => {
+      mockAxios.onPost(createReporterRoute()).reply(200)
+      const model = new SearchResultsModel()
+      const props = { searchResults: [] }
+      const result = {
+        data: {
+          first_name: 'first',
+          last_name: 'last',
+          phone_number: '123456789',
+          relationship_to_child: 'reporter'
+        }
+      }
+      model.createReporter(result)
+        .then(() => {
+          expect(mockAxios.history.post.length).toEqual(1)
+          done()
+        })
+    })
   })
 
   describe('validate', () => {


### PR DESCRIPTION
<!--- Dont forget the lable for PR -->

## Description
Calling the api endpoint for creating a person so that they can be searched for again. Right now the api is implemented with a mock.

## Jira Issue link
[REP-3](https://osi-cwds.atlassian.net/browse/REP-3)
[REP-58](https://osi-cwds.atlassian.net/browse/REP-58)

Notes:
* on the search page, the button says "Create Reporter" if nobody is selected, otherwise, it says "Continue" to keep going to the search page
