### PR TITLE
REP-99 make JsonBRE not a singleton

### DIFF
--- a/cares-ui/engine/src/jsonBRE.js
+++ b/cares-ui/engine/src/jsonBRE.js
@@ -5,10 +5,8 @@ import { length } from './customOperators'
 // singleton business rules engine
 export default class JsonBRE {
   constructor () {
-    if (JsonBRE.instance) { return JsonBRE.instance }
     this.rules = {}
     jsonLogic.add_operation('length', length)
-    JsonBRE.instance = this
   }
 
   evaluate (rule, data) {


### PR DESCRIPTION
<!--- Dont forget the lable for PR -->

## Description
JsonBRE engine does not need to be a singleton. If its a singleton than every instance contains all the rules, and we dont need that. We can load rulesets into the engine as needed.

## Jira Issue link
[REP-3](https://osi-cwds.atlassian.net/browse/REP-3)
[REP-99](https://osi-cwds.atlassian.net/browse/REP-99)