### PR TITLE
Fix missing and missing some in JsonBRE

### DIFF
--- a/cares-bre/cares-bre-services/src/main/resources/rules/jsonlogic/ReporterCreateScreenBusinessRules/reporter-create-first-name-required.json
+++ b/cares-bre/cares-bre-services/src/main/resources/rules/jsonlogic/ReporterCreateScreenBusinessRules/reporter-create-first-name-required.json
@@ -3,7 +3,7 @@
   "logic": {
     "if": [
       {
-        "missing": "create.reporter.first_name"
+        "missing": ["create.reporter.first_name"]
       },
       "A first name is required to create a reporter.",
       true

--- a/cares-bre/cares-bre-services/src/main/resources/rules/jsonlogic/ReporterCreateScreenBusinessRules/reporter-create-last-name-required.json
+++ b/cares-bre/cares-bre-services/src/main/resources/rules/jsonlogic/ReporterCreateScreenBusinessRules/reporter-create-last-name-required.json
@@ -3,7 +3,7 @@
   "logic": {
     "if": [
       {
-        "missing": "create.reporter.last_name"
+        "missing": ["create.reporter.last_name"]
       },
       "A last name is required to create a reporter.",
       true

--- a/cares-bre/cares-bre-services/src/main/resources/rules/jsonlogic/ReporterCreateScreenBusinessRules/reporter-create-phone-required.json
+++ b/cares-bre/cares-bre-services/src/main/resources/rules/jsonlogic/ReporterCreateScreenBusinessRules/reporter-create-phone-required.json
@@ -3,7 +3,7 @@
   "logic": {
     "if": [
       {
-        "missing": "create.reporter.phone_number"
+        "missing": ["create.reporter.phone_number"]
       },
       "A phone number is required to create a reporter.",
       true

--- a/cares-bre/cares-bre-services/src/main/resources/rules/jsonlogic/ReporterSearchScreenBusinessRules/reporter-search-name-required.json
+++ b/cares-bre/cares-bre-services/src/main/resources/rules/jsonlogic/ReporterSearchScreenBusinessRules/reporter-search-name-required.json
@@ -3,14 +3,7 @@
   "logic": {
     "if": [
       {
-        "and": [
-          {
-            "missing": ["search.reporter.first_name"]
-          },
-          {
-            "missing": ["search.reporter.last_name"]
-          }
-        ]
+        "missing_some": [1, ["search.reporter.first_name", "search.reporter.last_name"]]
       },
       "Last name or first name is required to search for a reporter.",
       true

--- a/cares-bre/cares-bre-services/src/main/resources/rules/jsonlogic/ReporterSearchScreenBusinessRules/reporter-search-name-required.json
+++ b/cares-bre/cares-bre-services/src/main/resources/rules/jsonlogic/ReporterSearchScreenBusinessRules/reporter-search-name-required.json
@@ -5,10 +5,10 @@
       {
         "and": [
           {
-            "missing": "search.reporter.first_name"
+            "missing": ["search.reporter.first_name"]
           },
           {
-            "missing": "search.reporter.last_name"
+            "missing": ["search.reporter.last_name"]
           }
         ]
       },

--- a/cares-bre/cares-bre-services/src/main/resources/rules/jsonlogic/ReporterSearchScreenBusinessRules/reporter-search-phone-required.json
+++ b/cares-bre/cares-bre-services/src/main/resources/rules/jsonlogic/ReporterSearchScreenBusinessRules/reporter-search-phone-required.json
@@ -3,7 +3,7 @@
   "logic": {
     "if": [
       {
-        "missing": "search.reporter.phone_number"
+        "missing": ["search.reporter.phone_number"]
       },
       "A phone number is required to search for a reporter.",
       true

--- a/cares-ui/engine/src/jsonObject.js
+++ b/cares-ui/engine/src/jsonObject.js
@@ -1,6 +1,8 @@
 import JsonMap from './jsonMap'
 import JsonEntity from './jsonEntity'
 import JsonSelector from './jsonSelector'
+import JsonSelectorArray from './jsonSelectorArray'
+import JsonSome from './jsonSome'
 import {
   ARRAY_OPERATIONS,
   DATA_OPERATIONS
@@ -13,6 +15,12 @@ export default class JsonObject {
 
     if (ARRAY_OPERATIONS.includes(operator)) {
       return new JsonMap(this.value)
+    }
+    if (operator === 'missing') {
+      return new JsonSelectorArray(this.value)
+    }
+    if (operator === 'missing_some') {
+      return new JsonSome(this.value)
     }
     if (DATA_OPERATIONS.includes(operator)) {
       return new JsonSelector(this.value)

--- a/cares-ui/engine/src/jsonSelectorArray.js
+++ b/cares-ui/engine/src/jsonSelectorArray.js
@@ -1,0 +1,11 @@
+import JsonSelector from './jsonSelector'
+
+export default class JsonSelectorArray {
+  constructor (values) {
+    this.entities = values.map((value) => new JsonSelector(value))
+  }
+
+  applies (selector) {
+    return this.entities.some((entity) => entity.applies(selector))
+  }
+}

--- a/cares-ui/engine/src/jsonSome.js
+++ b/cares-ui/engine/src/jsonSome.js
@@ -1,0 +1,12 @@
+import JsonSelectorArray from './jsonSelectorArray'
+
+export default class JsonSome {
+  constructor (definition) {
+    const selectorArray = definition[1]
+    this.value = new JsonSelectorArray(selectorArray)
+  }
+
+  applies (selector) {
+    return this.value.applies(selector)
+  }
+}

--- a/cares-ui/engine/test/features/dataOperators.test.js
+++ b/cares-ui/engine/test/features/dataOperators.test.js
@@ -1,37 +1,100 @@
 import JsonBRE from '../../src/jsonBRE'
 import Rule from '../../src/rule'
-import { DATA_OPERATIONS } from '../../src/operations.js'
 
 describe('Data Accessor Operators', () => {
-  DATA_OPERATIONS.map((operation) =>
-    describe(`"${operation}"`, () => {
-      it('must be supported', () => {
-        const definition = {}
-        definition[operation] = "client"
-        const rule = new Rule({
-          identifier: `${operation}`,
-          definition
-        })
-        const engine = new JsonBRE()
-        engine.define(rule)
-        expect(engine.find((rule) => rule.applies("client"))).toEqual([rule])
-        engine.reset()
+  describe(`"var"`, () => {
+    it('must be supported', () => {
+      const definition = {
+        "var": "client"
+      }
+      const rule = new Rule({
+        identifier: "var",
+        definition
       })
-
-      it('must support dot notation', () => {
-        const definition = {}
-        definition[operation] = "client.name"
-        const rule = new Rule({
-          identifier: `${operation}`,
-          definition
-        })
-        const engine = new JsonBRE()
-        engine.define(rule)
-        expect(engine.find((rule) => rule.applies("client.name"))).toEqual([rule])
-        expect(engine.find((rule) => rule.applies("client"))).toEqual([rule])
-        expect(engine.find((rule) => rule.applies("name"))).toEqual([rule])
-        engine.reset()
-      })
+      const engine = new JsonBRE()
+      engine.define(rule)
+      expect(engine.find((rule) => rule.applies("client"))).toEqual([rule])
+      engine.reset()
     })
-  )
+
+    it('must support dot notation', () => {
+      const definition = {
+        "var": "client.name"
+      }
+      const rule = new Rule({
+        identifier: "var",
+        definition
+      })
+      const engine = new JsonBRE()
+      engine.define(rule)
+      expect(engine.find((rule) => rule.applies("client.name"))).toEqual([rule])
+      expect(engine.find((rule) => rule.applies("client"))).toEqual([rule])
+      expect(engine.find((rule) => rule.applies("name"))).toEqual([rule])
+      engine.reset()
+    })
+  })
+
+  describe(`"missing"`, () => {
+    it('must be supported', () => {
+      const definition = {
+        "missing": ["client"]
+      }
+      const rule = new Rule({
+        identifier: "missing",
+        definition
+      })
+      const engine = new JsonBRE()
+      engine.define(rule)
+      expect(engine.find((rule) => rule.applies("client"))).toEqual([rule])
+      engine.reset()
+    })
+
+    it('must support dot notation', () => {
+      const definition = {
+        "missing": ["client.name"]
+      }
+      const rule = new Rule({
+        identifier: "var",
+        definition
+      })
+      const engine = new JsonBRE()
+      engine.define(rule)
+      expect(engine.find((rule) => rule.applies("client.name"))).toEqual([rule])
+      expect(engine.find((rule) => rule.applies("client"))).toEqual([rule])
+      expect(engine.find((rule) => rule.applies("name"))).toEqual([rule])
+      engine.reset()
+    })
+  })
+
+  describe(`"missing_some"`, () => {
+    it('must be supported', () => {
+      const definition = {
+        "missing_some": [1, ["client"]]
+      }
+      const rule = new Rule({
+        identifier: "missing_some",
+        definition
+      })
+      const engine = new JsonBRE()
+      engine.define(rule)
+      expect(engine.find((rule) => rule.applies("client"))).toEqual([rule])
+      engine.reset()
+    })
+
+    it('must support dot notation', () => {
+      const definition = {
+        "missing_some": [1, ["client.name"]]
+      }
+      const rule = new Rule({
+        identifier: "missing_some",
+        definition
+      })
+      const engine = new JsonBRE()
+      engine.define(rule)
+      expect(engine.find((rule) => rule.applies("client.name"))).toEqual([rule])
+      expect(engine.find((rule) => rule.applies("client"))).toEqual([rule])
+      expect(engine.find((rule) => rule.applies("name"))).toEqual([rule])
+      engine.reset()
+    })
+  })
 })

--- a/cares-ui/src/rules/first-name-required-rule.json
+++ b/cares-ui/src/rules/first-name-required-rule.json
@@ -1,6 +1,6 @@
 {
   "if": [
-    { "in": [ "firstName", { "missing": "firstName" }] },
+    { "in": [ "firstName", { "missing": ["firstName"] }] },
     "First name is required.",
     true
   ]

--- a/cares-ui/src/rules/last-name-required-rule.json
+++ b/cares-ui/src/rules/last-name-required-rule.json
@@ -1,6 +1,6 @@
 {
   "if": [
-    { "in": [ "lastName", { "missing": "lastName" }] },
+    { "in": [ "lastName", { "missing": ["lastName"] }] },
     "Last name is required.",
     true
   ]


### PR DESCRIPTION
<!--- Dont forget the lable for PR -->

## Description
There was a bug where the JsonLogic "missing_some" operator was not working. In addition, JsonLogic documentation states that the argument to `missing` and `missing_some` is an array. We were providing strings to `missing` and it was still working. However, in order to be consistent with the documentation and the definition of these two methods, I changed the rules in BRE API to use an array and fixed the engine.
## Jira Issue link
No Issue
